### PR TITLE
allow this module to be consumed as an XCode Package

### DIFF
--- a/Common/SimplePing.h
+++ b/Common/SimplePing.h
@@ -9,6 +9,7 @@
 @import Foundation;
 
 #include <AssertMacros.h>           // for __Check_Compile_Time
+#include <sys/socket.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SimplePing",
+    products: [
+        .library(
+            name: "SimplePing",
+            targets: ["SimplePing"]),
+    ],
+    targets: [
+        .target(
+            name: "SimplePing",
+            path: "Common",
+            publicHeadersPath: "."),
+    ]
+)

--- a/SimplePing.xcodeproj/project.pbxproj
+++ b/SimplePing.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5A3179A82DC87A7B0004E11C /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		834A91482439435900CDE7C2 /* SimplePingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePingManager.swift; sourceTree = "<group>"; };
 		8DD76FB20486AB0100D96B5E /* SimplePing */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = SimplePing; sourceTree = BUILT_PRODUCTS_DIR; };
 		E473E9AA1C4FF27D0079BC19 /* SimplePingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SimplePingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,6 +56,7 @@
 		08FB7794FE84155DC02AAC07 /* SimplePing */ = {
 			isa = PBXGroup;
 			children = (
+				5A3179A82DC87A7B0004E11C /* Package.swift */,
 				E473E9F31C501E9A0079BC19 /* README.md */,
 				E473E9F21C501E9A0079BC19 /* LICENSE.txt */,
 				E473E9C31C4FF2EA0079BC19 /* Common */,

--- a/SimplePing.xcodeproj/xcshareddata/xcschemes/MacTool.xcscheme
+++ b/SimplePing.xcodeproj/xcshareddata/xcschemes/MacTool.xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DD76FA90486AB0100D96B5E"
+               BuildableName = "SimplePing"
+               BlueprintName = "MacTool"
+               ReferencedContainer = "container:SimplePing.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76FA90486AB0100D96B5E"
+            BuildableName = "SimplePing"
+            BlueprintName = "MacTool"
+            ReferencedContainer = "container:SimplePing.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "8.8.8.8"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76FA90486AB0100D96B5E"
+            BuildableName = "SimplePing"
+            BlueprintName = "MacTool"
+            ReferencedContainer = "container:SimplePing.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
* added Package.swift, to allow this module to be consumed as an XCode Package
* fixed compile error, there was a missing #include
* pass 8.8.8.8 via cmd line argument to MacTool, so that Run in XCode exercises the code